### PR TITLE
Update headers.ts for Antigravity 2.0.1

### DIFF
--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -15,7 +15,7 @@ export const OAUTH_CONFIG = {
   redirectUri: "http://localhost:3000/oauth-callback"
 };
 
-const ANTIGRAVITY_VERSION = "1.15.8";
+const ANTIGRAVITY_VERSION = "2.0.1";
 
 const PLATFORMS = ["darwin/x64", "darwin/arm64"] as const;
 


### PR DESCRIPTION
I had the bug: This version of Antigravity is no longer supported. Please upgrade to receive the latest features.